### PR TITLE
Remove nightly refs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ axum = { version = "0.6.4", optional = true }
 console_error_panic_hook = "0.1"
 console_log = "1"
 cfg-if = "1"
-leptos = { version = "0.4", features = ["nightly"] }
+leptos = { version = "0.4" }
 leptos_axum = { version = "0.4", optional = true }
-leptos_meta = { version = "0.4", features = ["nightly"] }
-leptos_router = { version = "0.4", features = ["nightly"] }
+leptos_meta = { version = "0.4" }
+leptos_router = { version = "0.4" }
 log = "0.4"
 simple_logger = "4"
 tokio = { version = "1.25.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 
 # Leptos Axum Starter Template
 
-This is a template for use with the [Leptos](https://github.com/leptos-rs/leptos) web framework and the [cargo-leptos](https://github.com/akesson/cargo-leptos) tool using [Axum](https://github.com/tokio-rs/axum).
+This is a template for use with the
+[Leptos](https://github.com/leptos-rs/leptos) web framework and the
+[cargo-leptos](https://github.com/akesson/cargo-leptos) tool using
+[Axum](https://github.com/tokio-rs/axum).
 
 ## Creating your template repo
 
@@ -16,6 +19,7 @@ cargo install cargo-leptos
 ```
 
 Then run
+
 ```bash
 cargo leptos new --git leptos-rs/start-axum
 ```
@@ -26,9 +30,11 @@ to generate a new project template.
 cd {{project-name}}
 ```
 
-to go to your newly created project.  
-Feel free to explore the project structure, but the best place to start with your application code is in `src/app.rs`.  
-Addtionally, Cargo.toml may need updating as new versions of the dependencies are released, especially if things are not working after a `cargo update`.
+to go to your newly created project.\
+Feel free to explore the project structure, but the best place to start with
+your application code is in `src/app.rs`.\
+Addtionally, Cargo.toml may need updating as new versions of the dependencies
+are released, especially if things are not working after a `cargo update`.
 
 ## Running your project
 
@@ -38,21 +44,26 @@ cargo leptos watch
 
 ## Installing Additional Tools
 
-By default, `cargo-leptos` uses `nightly` Rust, `cargo-generate`, and `sass`. If you run into any trouble, you may need to install one or more of these tools.
+`cargo-leptos` uses `cargo-generate`, and `sass`. If you run into any trouble,
+you may need to install one or more of these tools.
 
-1. `rustup toolchain install nightly --allow-downgrade` - make sure you have Rust nightly
-2. `rustup target add wasm32-unknown-unknown` - add the ability to compile Rust to WebAssembly
-3. `cargo install cargo-generate` - install `cargo-generate` binary (should be installed automatically in future)
+2. `rustup target add wasm32-unknown-unknown` - add the ability to compile Rust
+   to WebAssembly
+3. `cargo install cargo-generate` - install `cargo-generate` binary (should be
+   installed automatically in future)
 4. `npm install -g sass` - install `dart-sass` (should be optional in future
 
 ## Compiling for Release
+
 ```bash
 cargo leptos build --release
 ```
 
-Will generate your server binary in target/server/release and your site package in target/site
+Will generate your server binary in target/server/release and your site package
+in target/site
 
 ## Testing Your Project
+
 ```bash
 cargo leptos end-to-end
 ```
@@ -61,21 +72,25 @@ cargo leptos end-to-end
 cargo leptos end-to-end --release
 ```
 
-Cargo-leptos uses Playwright as the end-to-end test tool.  
+Cargo-leptos uses Playwright as the end-to-end test tool.\
 Tests are located in end2end/tests directory.
 
 ## Executing a Server on a Remote Machine Without the Toolchain
+
 After running a `cargo leptos build --release` the minimum files needed are:
 
 1. The server binary located in `target/server/release`
 2. The `site` directory and all files within located in `target/site`
 
 Copy these files to your remote server. The directory structure should be:
+
 ```text
 {{project-name}}
 site/
 ```
+
 Set the following environment variables (updating for your project as needed):
+
 ```text
 LEPTOS_OUTPUT_NAME="{{project-name}}"
 LEPTOS_SITE_ROOT="site"
@@ -83,4 +98,5 @@ LEPTOS_SITE_PKG_DIR="pkg"
 LEPTOS_SITE_ADDR="127.0.0.1:3000"
 LEPTOS_RELOAD_PORT="3001"
 ```
+
 Finally, run the server binary.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-
-[toolchain]
-channel = "nightly"


### PR DESCRIPTION
Note: The `markdownlint` extension made a bunch of changes that I would not want upstreamed, but this is for me personally anyway so I don't care too much.